### PR TITLE
Compile error, SPACE key (Linux)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -33,6 +33,8 @@ if test x"$enable_debugmessage" = xyes; then
    CPPFLAGS="$CPPFLAGS -D_DEBUG"
 fi
 
+CPPFLAGS="$CPPFLAGS -fpermissive"
+
 PKG_CHECK_MODULES([DEPS], [opencv])
 AC_SUBST(DEPS_CFLAGS)
 AC_SUBST(DEPS_LDFLAGS)

--- a/examples/webcam/webcam.cpp
+++ b/examples/webcam/webcam.cpp
@@ -79,7 +79,7 @@ int main(int argc,char *argv[])
         //
         // when [SPACE] key pressed, do decode.
         //
-        if(key==0x20&&!qr_decoder_is_busy(decoder)){
+        if((key==0x20 || key==1048608)&&!qr_decoder_is_busy(decoder)){
             key=-1;
 
             //


### PR DESCRIPTION
fixed compile error with -fpermissive, and SPACE key not working with the webcam sample
