### PR TITLE
Fix for automake >= 1.11.2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7,6 +7,9 @@ AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign])
 AC_CONFIG_SRCDIR([libdecodeqr/bitstream.cpp])
 
+# Fix for recent changes in automake
+m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
+
 # Checks for programs.
 AC_LANG([C++])
 AC_PROG_CXX


### PR DESCRIPTION
This was failing on Arch Linux (automake 1.15).

```
/usr/share/automake-1.15/am/ltlibrary.am: warning: 'libdecodeqr.la': linking libtool libraries using a non-POSIX
/usr/share/automake-1.15/am/ltlibrary.am: archiver requires 'AM_PROG_AR' in 'configure.ac'
libdecodeqr/Makefile.am:3:   while processing Libtool library 'libdecodeqr.la'
```

This should now work in both old and recent versions of automake.
